### PR TITLE
make ddeboer_vatin.vatin_validator service public

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="ddeboer_vatin.vatin_validator" />
             <tag name="validator.constraint_validator" alias="ddeboer_vatin.validator" />
         </service>
-        <service id="ddeboer_vatin.vatin_validator" class="Ddeboer\Vatin\Validator" public="false">
+        <service id="ddeboer_vatin.vatin_validator" class="Ddeboer\Vatin\Validator">
             <call method="setViesClient">
                 <argument type="service" id="ddeboer_vatin.vies.client" />
             </call>


### PR DESCRIPTION
Components that want to validate the VAT, for example an search system cant reuse the service as its none public.

For the RollerworksRecordFilterBundle I want to build a filter-type that can validate vat numbers.
