### PR TITLE
Allow Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
     "require": {
         "php": ">=7.2",
         "ddeboer/vatin": "^2.0",
-        "symfony/http-kernel": "^4.0 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.0 || ^5.0 || ^6.0",
-        "symfony/config": "^4.0 || ^5.0 || ^6.0",
-        "symfony/validator": "^4.0 || ^5.0 || ^6.0"
+        "symfony/http-kernel": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/config": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/validator": "^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "doctrine/annotations": "^1.2",
-        "symfony/framework-bundle": "^5.0 || ^6.0",
-        "symfony/yaml": "^5.0 || ^6.0"
+        "symfony/framework-bundle": "^5.0 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DependencyInjection/DdeboerVatinExtension.php
+++ b/src/DependencyInjection/DdeboerVatinExtension.php
@@ -17,7 +17,7 @@ class DdeboerVatinExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Validator/Constraints/Vatin.php
+++ b/src/Validator/Constraints/Vatin.php
@@ -41,7 +41,7 @@ class Vatin extends Constraint
         parent::__construct($options ?? [], $groups, $payload);
     }
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'ddeboer_vatin.validator';
     }

--- a/src/Validator/Constraints/VatinValidator.php
+++ b/src/Validator/Constraints/VatinValidator.php
@@ -34,7 +34,7 @@ class VatinValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (null === $value || '' === $value) {
             return;
@@ -56,7 +56,7 @@ class VatinValidator extends ConstraintValidator
      *
      * @return bool
      */
-    private function isValidVatin($value, $checkExistence)
+    private function isValidVatin($value, $checkExistence): bool
     {
         try {
             return $this->validator->isValid($value, $checkExistence);

--- a/tests/Functional/Model.php
+++ b/tests/Functional/Model.php
@@ -9,10 +9,12 @@ class Model
     /**
      * @Vatin
      */
+    #[Vatin]
     public $vat;
 
     /**
      * @Vatin(checkExistence=true)
      */
+    #[Vatin(checkExistence: true)]
     public $vatCheckExistence;
 }

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -15,6 +15,10 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/config/config.yml');
+        if (self::MAJOR_VERSION >= 7) {
+            $loader->load(__DIR__ . '/config/config_7.yml');
+        } else {
+            $loader->load(__DIR__ . '/config/config.yml');
+        }
     }
 }

--- a/tests/Functional/app/config/config_7.yml
+++ b/tests/Functional/app/config/config_7.yml
@@ -1,0 +1,10 @@
+framework:
+  secret: ddeboer
+  test: ~
+  validation:
+    enable_attributes: true
+
+services:
+  test.validator:
+    alias: validator
+    public: true

--- a/tests/Validator/Constraints/ValidatorTest.php
+++ b/tests/Validator/Constraints/ValidatorTest.php
@@ -5,11 +5,12 @@ namespace Ddeboer\VatinBundle\Tests\Validator\Constraints;
 use Ddeboer\Vatin\Validator;
 use Ddeboer\VatinBundle\Validator\Constraints\Vatin;
 use Ddeboer\VatinBundle\Validator\Constraints\VatinValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class ValidatorTest extends ConstraintValidatorTestCase
 {
-    protected function createValidator()
+    protected function createValidator(): ConstraintValidatorInterface
     {
         return new VatinValidator(new Validator());
     }


### PR DESCRIPTION
This PR is about silencing deprecations from Symfony 6+ by adding return types to the code base and allowing Symfony 7 components.

Symfony 7 removed support for annotations and moved to attributes, so different configuration for test kernel was needed. And of course adding attributes to the test model.