### PR TITLE
chore: fix ci deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         include:
           - { php-version: '7.2', dependencies: '--prefer-lowest' }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
add testruns for PHP 8.2 and 8.3