### PR TITLE
Switch to correct Symfony Extension namespace

### DIFF
--- a/src/DependencyInjection/DdeboerVatinExtension.php
+++ b/src/DependencyInjection/DdeboerVatinExtension.php
@@ -4,7 +4,7 @@ namespace Ddeboer\VatinBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
This PR fixes the deprecations:

```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Ddeboer\VatinBundle\DependencyInjection\DdeboerVatinExtension".
```

The correct extension class is available in all Symfony versions supported by this bundle and this change has no side effects.